### PR TITLE
feat: add disabled support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+phantomjs_cdnurl=http://npm.taobao.org/mirrors/phantomjs

--- a/tap.js
+++ b/tap.js
@@ -39,7 +39,10 @@ export default {
           el.removeEventListener('touchcancel', el._tap_touchcancel)
           el.removeEventListener('touchend', el._tap_touchend)
 
-          if (startPoint) {
+          // not fire tap event on disabled element
+          const disabled = e.currentTarget.disabled
+
+          if (startPoint && !disabled) {
             startPoint = null
 
             // dispatch a tap event

--- a/test/unit/specs/tap.spec.js
+++ b/test/unit/specs/tap.spec.js
@@ -91,6 +91,28 @@ describe('tap', () => {
     triggerTouchEvents(vm.$el, 'touchcancel')
   })
 
+  it('should NOT dispatch tap event on disabled element', done => {
+    vm = new Vue({
+      el,
+      template: '<button disabled v-tap @tap="onTap"></button>',
+      methods: {
+        onTap () {
+          assert(false, 'should NOT be called')
+        }
+      }
+    })
+
+    triggerTouchEvents(vm.$el, 'touchstart', e => {
+      e.touches = [{
+        pageX: 0,
+        pageY: 0
+      }]
+    })
+    triggerTouchEvents(vm.$el, 'touchend')
+
+    setTimeout(done, 500)
+  })
+
   it('should NOT dispatch tap event', done => {
     vm = new Vue({
       el,


### PR DESCRIPTION
if an element is marked as `disabled`, `tap` event should not be fired